### PR TITLE
Added flag disableCodeCoverageInstrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ coverageReporter: {
 browsers: ["PhantomJS"]
 ```
 
+If you want to debug your code and see the original TypeScript code, you can disable code coverage instrumentation using this configuration:
+
+```javascript
+karmaTypescriptConfig: {
+    disableCodeCoverageInstrumentation: true
+}
+```
+
 ## Requirements
 
 Typescript >=1.6 is required.

--- a/example-project/karma.conf.js
+++ b/example-project/karma.conf.js
@@ -25,6 +25,13 @@ module.exports = function(config) {
         },
         //*/
 
+        // Uncomment below if you want to disable code
+        // coverage instrumentation during debugging of
+        // tests
+        /*karmaTypescriptConfig: {
+            disableCodeCoverageInstrumentation: true
+        },*/
+
         browsers: ["Chrome"]
     });
 };

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -106,7 +106,7 @@ function chainPreprocessors(commonjsPreprocessor, coveragePreprocessor, done, fi
 
         commonjsPreprocessor(result, file, function(commonjsResult) {
 
-            if(specFileRegex.test(file.originalPath)) {
+            if(config.karmaTypescriptConfig.disableCodeCoverageInstrumentation || specFileRegex.test(file.originalPath)) {
 
                 log.debug("won't instrument spec file %s, done", file.originalPath);
                 done(null, commonjsResult);


### PR DESCRIPTION
Fixes #15.

Without this flag, when you are debugging your tests and try to step into code from some non-spec file, you get code instrumented by Istanbul instead of the original TypeScript.

This problem does not occur when stepping into code from *.spec files as they are already excluded from Istanbul instrumentation.