### PR TITLE
2.1.8

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -65,7 +65,10 @@ function Configuration() {
 
         self.coverageOptions = defaultTo(karmaTypescriptConfig.coverageOptions, {});
         self.coverageOptions.instrumentation = defaultTo(self.coverageOptions.instrumentation, true);
-        self.coverageOptions.exclude = defaultTo(self.coverageOptions.exclude, /\.(d|spec|test)\.ts/i);
+        self.coverageOptions.exclude = defaultTo(
+					checkCoverageOptionExclude(self.coverageOptions.exclude),
+					/\.(d|spec|test)\.ts/i
+				);
         self.transformPath = defaultTo(karmaTypescriptConfig.transformPath, function(filepath) {
             return filepath.replace(/\.(ts|tsx)$/, ".js");
         });
@@ -163,6 +166,27 @@ function Configuration() {
                 return arguments[i];
             }
         }
+    }
+
+    function checkCoverageOptionExclude(regex) {
+        function throwRegexError(regex) {
+            var baseErrorMsg = "karmaTypescriptConfig.coverageOptions.exclude must be a single RegExp or an Array of RegExp";
+            throw new Error( baseErrorMsg +	" " + regex + " is not a regex");
+        }
+			
+        if (regex instanceof RegExp || !regex) { // if value passed is a regex or undefined, go ahead
+            return regex;
+        }
+        else if (Array.isArray(regex)) { // if value is an array, check each item
+            regex.forEach(function(r) {
+                if (!(r instanceof RegExp)) { // if some item is not a regex, throw an error
+                    throwRegexError(r);
+                }
+            });
+            return regex; // else: keep going
+        }
+			// if it's something other, throw an error
+        throwRegexError(regex);
     }
 
     self.initialize = initialize;

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -32,8 +32,37 @@ function Coverage(config) {
             return;
         }
 
+        function doesOneRegexMatch(regexes, value) {
+            var results = regexes.map(function(regex) {
+                try {
+                    return regex.test(value);
+                }
+                catch(err) {
+                    throw new Error(value + " is not a regex, please provide only regexes");
+                }
+            });
+
+            var matches = results.filter(function(result) {
+                return result;
+            });
+
+            return matches.length > 0;
+        }
+
+        function checkRegex(regex, value) {
+            if (regex instanceof Array) {
+                return doesOneRegexMatch(regex, value);
+            }
+            else if (regex instanceof RegExp) {
+                return regex.test(value);
+            }
+            else {
+                throw new Error("karmaTypescriptConfig.coverageOptions.exclude must be a single RegExp or an Array of RegExp");
+            }
+        }
+
         if(!config.coverageOptions.instrumentation ||
-           config.coverageOptions.exclude.test(file.originalPath) ||
+           checkRegex(config.coverageOptions.exclude, file.originalPath) ||
            hasNoOutput(file, emitOutput)) {
 
             log.debug("Excluding file %s from instrumentation", file.originalPath);

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -34,12 +34,7 @@ function Coverage(config) {
 
         function doesOneRegexMatch(regexes, value) {
             var results = regexes.map(function(regex) {
-                try {
-                    return regex.test(value);
-                }
-                catch(err) {
-                    throw new Error(value + " is not a regex, please provide only regexes");
-                }
+                return regex.test(value);
             });
 
             var matches = results.filter(function(result) {
@@ -53,12 +48,7 @@ function Coverage(config) {
             if (Array.isArray(regex)) {
                 return doesOneRegexMatch(regex, value);
             }
-            else if (regex instanceof RegExp) {
-                return regex.test(value);
-            }
-            else {
-                throw new Error("karmaTypescriptConfig.coverageOptions.exclude must be a single RegExp or an Array of RegExp");
-            }
+            return regex.test(value);
         }
 
         if(!config.coverageOptions.instrumentation ||

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -50,7 +50,7 @@ function Coverage(config) {
         }
 
         function checkRegex(regex, value) {
-            if (regex instanceof Array) {
+            if (Array.isArray(regex)) {
                 return doesOneRegexMatch(regex, value);
             }
             else if (regex instanceof RegExp) {


### PR DESCRIPTION
Adds possibility for passing an Array of Regexes to the `coverageOptions.exclude` property.
Throws errors with useful information if something wrong got passed in.

No unittests and not covered in integration tests (yet)

https://github.com/monounity/karma-typescript/issues/85