### PR TITLE
add more description to minimal configuration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ module.exports = function(config) {
         frameworks: ["jasmine", "karma-typescript"],
         files: [
             { pattern: "src/**/*.ts" }, // *.tsx for React Jsx
+            { pattern: "test/**/*.ts" }
         ],
         preprocessors: {
-            "**/*.ts": ["karma-typescript"], // *.tsx for React Jsx
+            "src/**/*.ts": ["karma-typescript", "coverage"], // *.tsx for React Jsx
+            "test/**/*.ts": ["karma-typescript"]
         },
         reporters: ["progress", "karma-typescript"],
         browsers: ["Chrome"]


### PR DESCRIPTION
I've spent a day trying to figure this out and experimenting with webpack based solutions.  I'd recommend adding a bit more to the minimal configuration displayed in the readme.  

Two things:

The a number of the webpack solutions required that all the source and test files get bundled into a single entry point.  As I understand, this does not as one would not necessarily want coverage run on the tests themselves.  To this end, I added a second entry in the files array to distinguish test and source resources.  

In the preprocessors sections, I added coverage to source resources but not to the test resources.  I discovered that this needed to be done to produce the output only by stumbling accross the issue discussion in the repo.  I think a more prominent location in the readme would reduce user confusion.  