### PR TITLE
Removed tests from NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ coverage
 node_modules
 npm-debug.log
 tmp
+tests

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The easiest way is to keep `karma-typescript` as a devDependency in `package.jso
 {
   "devDependencies": {
     "karma": "^1.5.0",
-    "karma-typescript": "3.0.5"
+    "karma-typescript": "3.0.6"
   }
 }
 ```

--- a/examples/angular2/package.json
+++ b/examples/angular2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-angular2",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Example project for Angular2",
   "author": "monounity",
   "contributors": [

--- a/examples/angularjs/package.json
+++ b/examples/angularjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-angularjs",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Example project for AngularJS 1.5",
   "author": "monounity",
   "contributors": [

--- a/examples/docker/package.json
+++ b/examples/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-docker",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "author": "monounity",
   "contributors": [

--- a/examples/gulp/package.json
+++ b/examples/gulp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foobar",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Example project for running a sequence of gulp tasks, issue https://github.com/monounity/karma-typescript/issues/29",
   "author": "https://github.com/kubut",
   "main": "index.js",

--- a/examples/mocha/package.json
+++ b/examples/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-mocha",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "author": "monounity",
   "contributors": [

--- a/examples/typescript-1.6.2/package.json
+++ b/examples/typescript-1.6.2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-1-6-2",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "author": "monounity",
   "contributors": [

--- a/examples/typescript-latest/package.json
+++ b/examples/typescript-latest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript-examples-latest",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "author": "monounity",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-typescript",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Simplifying running unit tests with coverage for Typescript projects.",
   "main": "dist/index.js",
   "keywords": [

--- a/tests/integration-1.8.10/package.json
+++ b/tests/integration-1.8.10/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-integration-1-8-10",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Integration tests for Typescript 1.8.10",
   "author": "monounity",
   "contributors": [

--- a/tests/integration-latest/bower.json
+++ b/tests/integration-latest/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-integration-latest",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "license": "MIT",
   "private": true,

--- a/tests/integration-latest/package.json
+++ b/tests/integration-latest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-integration-latest",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Integration tests for the latest version of Typescript",
   "author": "monounity",
   "contributors": [


### PR DESCRIPTION
This reduces bundle size by ~17MB. Mostly because of `x-performance`.