### PR TITLE
Manually run 'prepare' script in integration-latest test directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 
 node_js: 6
 
-before_install:
-  - npm install -g npm@4
-
 install:
   - ./ci/install.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm -g install npm@4
   - set PATH=%APPDATA%\npm;%PATH%
   - node -v
   - npm -v

--- a/ci/install.bat
+++ b/ci/install.bat
@@ -21,6 +21,7 @@ call npm i
 
 cd ..\integration-latest
 call npm i
+call npm run prepare
 
 cd ..\..
 call npm i

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -34,6 +34,7 @@ npm i
 cd ../integration-latest
 pwd
 npm i
+npm run prepare
 
 cd ../..
 pwd


### PR DESCRIPTION
`npm@3`, which is the version of `npm` for NodeJS stable, does not automatically run `prepare` before install. Therefore, it must be manually invoked for `integration-latest`, otherwise bower components won't be set up