### PR TITLE
Adds karma and typescript as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,11 @@
     "tape": "^4.6.3",
     "tslint": "^4.4.2",
     "tslint-eslint-rules": "^3.3.0",
-    "typescript": "latest"
+    "typescript": "2"
+  },
+  "peerDependencies": {
+    "karma": "1",
+    "typescript": "2"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Note that [karma-babel-preprocesser](https://github.com/babel/karma-babel-preprocessor/blob/master/package.json#L31) uses `peerDepenencies` to show that it _does_ depend on certain libraries, but it wants the dependent project to define the dependencies.

This PR applies the same philosophy to `karma-typescript`, with the understanding that we can't (err, shouldn't :wink:) hardcode our `typescript` and `karma` dependencies