### PR TITLE
Support processing JS produced by transformers.

### DIFF
--- a/src/api/transforms.ts
+++ b/src/api/transforms.ts
@@ -4,8 +4,15 @@ import * as ts from "typescript";
 
 import { Configuration } from "../shared/configuration";
 
+export interface TransformResult {
+    dirty?: boolean;
+    transpile?: boolean;
+    transformedScript?: boolean;
+}
+
 export interface TransformCallback {
     (error: Error, dirty: boolean, transpile?: boolean): void;
+    (error: Error, result: TransformResult): void;
 };
 
 export interface TransformContextJs{

--- a/src/bundler/bundle-item.ts
+++ b/src/bundler/bundle-item.ts
@@ -4,6 +4,7 @@ export class BundleItem {
 
     public ast?: ESTree.Program;
     public lookupName?: string;
+    public transformedScript = false;
 
     constructor(public moduleName: string, public filename?: string,
                 public source?: string, public dependencies: BundleItem[] = []) {}
@@ -13,7 +14,8 @@ export class BundleItem {
     }
 
     public isScript(): boolean {
-        return this.filename && /\.(js|jsx|ts|tsx)$/.test(this.filename);
+        return (this.filename && /\.(js|jsx|ts|tsx)$/.test(this.filename))
+            || this.transformedScript;
     }
 
     public isTypingsFile(): boolean {


### PR DESCRIPTION
Fixes #217 

This PR adds a new callback parameter to transformers: `transpile`. 
When set to true by transformer, `bundleItem` is then considered as a normal script rather than just contents. This means that the bundler will process its dependencies and include them, so you can `require()` to your heart's contents.

There is no compatibility issue since this is a new parameter and when it's not set the code behaves exactly like before.

**BIG GOTCHA** 
`karma-typescript` never compiles the `source` into `ast` after transformers are run. 
As can be seen in the code, it expects transformers to provide their own AST:
https://github.com/monounity/karma-typescript/blob/master/src/bundler/transformer.ts#L89

So in order for the new option to effectively work, transformer has to do this:
```js
content.js.ast = acorn.parse(content.source, content.config.bundlerOptions.acornOptions);
```
This is not user-friendly but I did not want to change the current code expectations.
I think a good compromise would be to do the above call automatically when `transpile == true` and `content.js.ast == undefined`.

This was tested on my project and works, if you mind the gotcha.