### PR TITLE
fix: karma-typescript fails on npm install command 

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "log4js": "^1.1.1",
     "minimatch": "^3.0.3",
     "os-browserify": "^0.3.0",
-    "pad": "^1.1.0",
+    "pad": "^2.0.0",
     "path-browserify": "0.0.0",
     "process": "^0.11.10",
     "punycode": "^1.4.1",


### PR DESCRIPTION
Relates to https://github.com/jashkenas/coffeescript/issues/4805

pad update to the latest coffeescript and released a major version

This is breaking a lot of windows users

Closes: #221 