### PR TITLE
Allow Karma@2 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "typescript": "2"
   },
   "peerDependencies": {
-    "karma": "1",
+    "karma": "1 || 2",
     "typescript": "2"
   },
   "collective": {


### PR DESCRIPTION
Fixes the following warning:

> npm WARN karma-typescript@3.0.9 requires a peer of karma@1 but none is installed. You must install peer dependencies yourself.