### PR TITLE
Update remap-instanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "punycode": "^1.4.1",
     "querystring-es3": "^0.2.1",
     "readable-stream": "^2.3.3",
-    "remap-istanbul": "^0.8.4",
+    "remap-istanbul": "^0.10.0",
     "source-map": ">=0.5.6",
     "stream-browserify": "^2.0.1",
     "stream-http": "^2.7.2",


### PR DESCRIPTION
Update with https://github.com/SitePen/remap-istanbul/pull/158 to get rid of deprecation warning.

> npm WARN deprecated gulp-util@3.0.7: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5