### PR TITLE
Remove unnecessary files from bundle to reduce size and avoid issues with typings.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,7 @@ node_modules
 npm-debug.log
 tmp
 tests
+examples
+assets
+ci
+src


### PR DESCRIPTION
Examples folder contains a jasmine.d.ts that conflicts with @types/jasmine.