### PR TITLE
Added support for karma 3.x and typescript 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "json-stringify-safe": "^5.0.1",
     "karma-coverage": "^1.1.1",
     "lodash": "^4.17.4",
-    "log4js": "^1.1.1",
+    "log4js": "^3.0.5",
     "minimatch": "^3.0.3",
     "os-browserify": "^0.3.0",
     "pad": "^2.0.0",
@@ -110,9 +110,8 @@
     "@types/estree": "0.0.38",
     "@types/glob": "^5.0.30",
     "@types/istanbul": "^0.4.29",
-    "@types/karma": "^0.13.33",
+    "@types/karma": "^1.7.6",
     "@types/lodash": "^4.14.59",
-    "@types/log4js": "0.0.33",
     "@types/minimatch": "^2.0.29",
     "@types/mock-require": "^1.3.3",
     "@types/node": "^7.0.5",
@@ -136,11 +135,11 @@
     "tape": "^4.6.3",
     "tslint": "^4.4.2",
     "tslint-eslint-rules": "^3.3.0",
-    "typescript": "2"
+    "typescript": "^3.1.1"
   },
   "peerDependencies": {
-    "karma": "1 || 2",
-    "typescript": "2"
+    "karma": "1 || 2 || 3",
+    "typescript": "2 || 3"
   },
   "collective": {
     "type": "opencollective",

--- a/src/api/transforms.ts
+++ b/src/api/transforms.ts
@@ -13,7 +13,7 @@ export interface TransformResult {
 export interface TransformCallback {
     (error: Error, dirty: boolean, transpile?: boolean): void;
     (error: Error, result: TransformResult): void;
-};
+}
 
 export interface TransformContextJs{
     ast: ESTree.Program;
@@ -35,7 +35,7 @@ export interface TransformContext {
 }
 
 export interface TransformInitializeLogOptions {
-    appenders: log4js.AppenderConfigBase[];
+    appenders: { [name: string]: log4js.Appender } | log4js.Appender[];
     level: string;
 }
 
@@ -46,4 +46,4 @@ export interface TransformInitialize {
 export interface Transform {
     (context: TransformContext, callback: TransformCallback): void;
     initialize?: TransformInitialize;
-};
+}

--- a/src/shared/configuration.ts
+++ b/src/shared/configuration.ts
@@ -88,11 +88,24 @@ export class Configuration implements KarmaTypescriptConfig {
     }
 
     private configureLogging() {
+        const appenders = this.karma.loggers instanceof Array
+            ? this.karma.loggers.reduce((acc, logger, index) => Object.assign(acc, { ["index" + index]: logger }), {})
+            : this.karma.loggers;
 
-        log4js.configure({ appenders: this.karma.loggers });
+        if (appenders != null) {
+            log4js.configure({
+                appenders,
+                categories: {
+                    default: {
+                        appenders: Object.keys(appenders),
+                        level: this.karma.logLevel
+                    }
+                }
+            });
+        }
 
         Object.keys(this.loggers).forEach((key) => {
-            this.loggers[key].setLevel(this.karma.logLevel);
+            this.loggers[key].level = this.karma.logLevel;
         });
     }
 

--- a/tests/integration-latest/package.json
+++ b/tests/integration-latest/package.json
@@ -58,7 +58,7 @@
     "indent-string": "^3.1.0",
     "jasmine-core": "^2.6.0",
     "jsonld": "^0.4.12",
-    "karma": "^2.0.0",
+    "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",

--- a/tests/integration-latest/src/typescript/compiler-paths/compiler-paths-tester.ts
+++ b/tests/integration-latest/src/typescript/compiler-paths/compiler-paths-tester.ts
@@ -1,4 +1,6 @@
 import { Subject } from "@nodeModules/rxjs";
+// Ignore implicit any error on the module without type definitions.
+// @ts-ignore
 import * as acorn from "@outsideProject/acorn";
 
 export class CompilerPathsTester {


### PR DESCRIPTION
Updated log4js to the latest as this is the version, which karma@3.0.0 uses.
Changes to logging configuration is to account for the corrected `karma` type definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29386