### PR TITLE
Add support for resolveJsonModule

### DIFF
--- a/src/bundler/bundle-item.ts
+++ b/src/bundler/bundle-item.ts
@@ -25,6 +25,6 @@ export class BundleItem {
     }
 
     public isTypescriptFile(): boolean {
-        return this.filename && !this.isTypingsFile() && /\.(ts|tsx)$/.test(this.filename);
+        return this.filename && !this.isTypingsFile() && /\.(ts|tsx|json)$/.test(this.filename);
     }
 }

--- a/tests/integration-latest/src/imports/json-import/json-direct-import.ts
+++ b/tests/integration-latest/src/imports/json-import/json-direct-import.ts
@@ -1,0 +1,7 @@
+
+import pkgData from "stream-http/package.json";
+import data from "./json-import-tester.json";
+
+
+export const local = data;
+export const pkg = pkgData;

--- a/tests/integration-latest/src/imports/json-import/json-import-tester.spec.ts
+++ b/tests/integration-latest/src/imports/json-import/json-import-tester.spec.ts
@@ -18,4 +18,10 @@ describe("JsonImporter", () => {
 
         expect(tester.testRequireModuleRequiringJSON()).not.toBeUndefined();
     });
+
+    it("should support TS import of a json file", () => {
+        const { local, pkg } = tester.testTSImportJSON();
+        expect(local).toEqual([1, 2, 3, "a", "b", "c"]);
+        expect(pkg).not.toBeUndefined();
+    });
 });

--- a/tests/integration-latest/src/imports/json-import/json-import-tester.ts
+++ b/tests/integration-latest/src/imports/json-import/json-import-tester.ts
@@ -15,4 +15,9 @@ export class JsonImportTester {
         // globals@9.14.0 requires a JSON file
         return require("globals");
     }
+
+    public testTSImportJSON(): any {
+
+        return require("./json-direct-import");
+    }
 }

--- a/tests/integration-latest/tsconfig.json
+++ b/tests/integration-latest/tsconfig.json
@@ -8,6 +8,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "outDir": "tmp",
+        "resolveJsonModule": true,
         "target": "ES5",
         "allowSyntheticDefaultImports": true,
         "baseUrl": ".",


### PR DESCRIPTION
Allows for direct imports of json into typescript.

Fixes #291.

TODO: Typescript will automatically resolve typings of the imported json (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#new---resolvejsonmodule). How do I add a test to ensure that TS complains if I use the imported data incorrectly?