### PR TITLE
Fix #319: external npm modules must not become bundle items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 npm-debug.log
 package-lock.json
 tmp
+.idea
+tests/**/*.js

--- a/packages/karma-typescript/src/bundler/resolve/resolver.ts
+++ b/packages/karma-typescript/src/bundler/resolve/resolver.ts
@@ -37,7 +37,7 @@ export class Resolver {
                          buffer: BundleItem[],
                          onModuleResolved: (bundleItem: BundleItem) => void) {
 
-        if (bundleItem.isTypescriptFile()) {
+        if (bundleItem.isTypescriptFile() && !bundleItem.isNpmModule()) {
             process.nextTick(() => {
                 onModuleResolved(bundleItem);
             });


### PR DESCRIPTION
This adds an additional guard to the resolver, preventing npm modules that include their original typescript sources from being recognised as part of the current project.