### PR TITLE
Fix project references

### DIFF
--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -112,7 +112,7 @@ test("transformer should use custom options", (t) => {
                                   "WVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDZCQUFlO0FBQWYsb0JBQW" +
                                   "U7QUFBZix3QkFBZTtBQUFmLHlCQUFlO0FBQWYsZUFBZSIsImZpbGU" +
                                   "iOiJmaWxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIjo6cGxhY2Vo" +
-                                  "b2xkZXIge30iXX0=*/");
+                                  "b2xkZXIge30iXX0= */");
     });
 });
 

--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -112,7 +112,7 @@ test("transformer should use custom options", (t) => {
                                   "WVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDZCQUFlO0FBQWYsb0JBQW" +
                                   "U7QUFBZix3QkFBZTtBQUFmLHlCQUFlO0FBQWYsZUFBZSIsImZpbGU" +
                                   "iOiJmaWxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIjo6cGxhY2Vo" +
-                                  "b2xkZXIge30iXX0 */");
+                                  "b2xkZXIge30iXX0=*/");
     });
 });
 

--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -102,9 +102,9 @@ test("transformer should use custom options", (t) => {
     const context = createContext("::placeholder {}");
 
     transform(require("autoprefixer"), { map: { inline: true } })(context, () => {
-        t.isEqual(context.source, "::-webkit-input-placeholder {}" +
+        t.isEqual(context.source, "::-webkit-input-placeholder {}\n" +
                                   "::-moz-placeholder {}\n" +
-                                  "\n:-ms-input-placeholder {}\n" +
+                                  ":-ms-input-placeholder {}\n" +
                                   "::-ms-input-placeholder {}" +
                                   "\n::placeholder {}" +
                                   "\n/*# sourceMappingURL=data:application/json;base64," +

--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -90,6 +90,7 @@ test("transformer should set the source property to the processed value", (t) =>
 
     transform(require("autoprefixer"))(context, () => {
         t.isEqual(context.source, "::-webkit-input-placeholder {}\n" +
+                                  "::-moz-placeholder {}\n" +
                                   ":-ms-input-placeholder {}\n" +
                                   "::-ms-input-placeholder {}\n::placeholder {}");
     });
@@ -107,9 +108,10 @@ test("transformer should use custom options", (t) => {
                                   "\n::placeholder {}" +
                                   "\n/*# sourceMappingURL=data:application/json;base64," +
                                   "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpbGUuY3NzIl0sIm5hb" +
-                                  "WVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDZCQUFlO0FBQWYsd0JBQW" +
-                                  "U7QUFBZix5QkFBZTtBQUFmLGVBQWUiLCJmaWxlIjoiZmlsZS5jc3M" +
-                                  "iLCJzb3VyY2VzQ29udGVudCI6WyI6OnBsYWNlaG9sZGVyIHt9Il19 */");
+                                  "WVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDZCQUFlO0FBQWYsb0JBQW" +
+                                  "U7QUFBZix3QkFBZTtBQUFmLHlCQUFlO0FBQWYsZUFBZSIsImZpbGU" +
+                                  "iOiJmaWxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIjo6cGxhY2Vo" +
+                                  "b2xkZXIge30iXX0 */");
     });
 });
 

--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -103,6 +103,7 @@ test("transformer should use custom options", (t) => {
 
     transform(require("autoprefixer"), { map: { inline: true } })(context, () => {
         t.isEqual(context.source, "::-webkit-input-placeholder {}" +
+                                  "::-moz-placeholder {}\n" +
                                   "\n:-ms-input-placeholder {}\n" +
                                   "::-ms-input-placeholder {}" +
                                   "\n::placeholder {}" +

--- a/packages/karma-typescript/src/client/commonjs.ts
+++ b/packages/karma-typescript/src/client/commonjs.ts
@@ -1,4 +1,4 @@
-((global) => {
+((global: any) => {
     "use strict";
     global.__karmaTypescriptModules__ =  {};
     const fn = 0;

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -11,7 +11,7 @@ import { CompileCallback } from "./compile-callback";
 
 interface CompiledFiles { [key: string]: string; }
 
-    interface Queued {
+interface Queued {
     file: File;
     callback: CompileCallback;
 }

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -11,7 +11,7 @@ import { CompileCallback } from "./compile-callback";
 
 interface CompiledFiles { [key: string]: string; }
 
-interface Queued {
+    interface Queued {
     file: File;
     callback: CompileCallback;
 }
@@ -61,7 +61,13 @@ export class Compiler {
 
         this.outputDiagnostics(tsconfig.errors);
 
-        this.program = ts.createProgram(tsconfig.fileNames, tsconfig.options, this.compilerHost);
+        this.program = ts.createProgram({
+            rootNames: tsconfig.fileNames,
+            options: tsconfig.options,
+            projectReferences: tsconfig.projectReferences,
+            host: this.compilerHost
+        });
+
         this.cachedProgram = this.program;
 
         this.runDiagnostics(this.program, this.compilerHost);

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -61,12 +61,16 @@ export class Compiler {
 
         this.outputDiagnostics(tsconfig.errors);
 
-        this.program = ts.createProgram({
-            host: this.compilerHost,
-            options: tsconfig.options,
-            projectReferences: tsconfig.projectReferences,
-            rootNames: tsconfig.fileNames
-        });
+        if(+ts.version[0] >= 3 ) {
+            this.program = ts.createProgram({
+                host: this.compilerHost,
+                options: tsconfig.options,
+                projectReferences: tsconfig.projectReferences,
+                rootNames: tsconfig.fileNames
+            });
+        } else {
+            this.program = ts.createProgram(tsconfig.fileNames, tsconfig.options, this.compilerHost);
+        }
 
         this.cachedProgram = this.program;
 

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -62,10 +62,10 @@ export class Compiler {
         this.outputDiagnostics(tsconfig.errors);
 
         this.program = ts.createProgram({
-            rootNames: tsconfig.fileNames,
+            host: this.compilerHost,
             options: tsconfig.options,
             projectReferences: tsconfig.projectReferences,
-            host: this.compilerHost
+            rootNames: tsconfig.fileNames
         });
 
         this.cachedProgram = this.program;

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -61,14 +61,15 @@ export class Compiler {
 
         this.outputDiagnostics(tsconfig.errors);
 
-        if(+ts.version[0] >= 3 ) {
+        if (+ts.version[0] >= 3) {
             this.program = ts.createProgram({
                 host: this.compilerHost,
                 options: tsconfig.options,
                 projectReferences: tsconfig.projectReferences,
                 rootNames: tsconfig.fileNames
             });
-        } else {
+        }
+        else {
             this.program = ts.createProgram(tsconfig.fileNames, tsconfig.options, this.compilerHost);
         }
 


### PR DESCRIPTION
TypeScript 3.0 added support for [project references](https://www.typescriptlang.org/docs/handbook/project-references.html), allowing for quickly building large projects. A list of project references is provided by `ts.parseJsonConfigFileContent`, which is assigned to `tsconfig` at `compiler.ts`. The property is `projectReferences`.

The property value should be passed to `ts.createProgram` by using a new signature that supports projectReferences. This PR implements the requirement, allowing for the usage of project references alongside karma-typescript.
