### PR TITLE
Support incremental compiler API, fixes #347

### DIFF
--- a/examples/typescript-latest/karma.conf.js
+++ b/examples/typescript-latest/karma.conf.js
@@ -13,6 +13,10 @@ module.exports = function(config) {
 
         reporters: ["dots", "karma-typescript"],
 
+        karmaTypescriptConfig: {
+            tsconfig: "./tsconfig.json"
+        },
+
         browsers: ["ChromeHeadless"],
 
         singleRun: true

--- a/examples/typescript-latest/tsconfig.json
+++ b/examples/typescript-latest/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compileOnSave": false,
     "compilerOptions": {
+        "incremental": true,
         "module": "commonjs",
         "noImplicitAny": true,
         "outDir": "tmp",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "lerna run build",
     "lint": "lerna run lint",
     "test": "lerna run test",
-    "test:examples": "npm run test:examples:angular && npm run test:examples:typescript-latest",
+    "test:examples": "npm run test:examples:angular && npm run test:examples:typescript-1.6.2 && npm run test:examples:typescript-1.8.10 && npm run test:examples:typescript-latest",
     "test:examples:angular": "npm --prefix examples/angular2/ test",
     "test:examples:typescript-1.6.2": "npm --prefix examples/typescript-1.6.2/ test",
     "test:examples:typescript-1.8.10": "npm --prefix examples/typescript-1.8.10/ test",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "lerna run build",
     "lint": "lerna run lint",
     "test": "lerna run test",
-    "test:examples": "npm run test:examples:angular && npm run test:examples:typescript-1.6.2 && npm run test:examples:typescript-1.8.10 && npm run test:examples:typescript-latest",
+    "test:examples": "npm run test:examples:angular && npm run test:examples:typescript-latest",
     "test:examples:angular": "npm --prefix examples/angular2/ test",
     "test:examples:typescript-1.6.2": "npm --prefix examples/typescript-1.6.2/ test",
     "test:examples:typescript-1.8.10": "npm --prefix examples/typescript-1.8.10/ test",


### PR DESCRIPTION
- Works when running `npx karma start --no-single-run` in example/typescript-latest
- The compiler is kind of butchered, it doesn't support older versions of `typescript` than 3.6.* yet
- No configuration added