### PR TITLE
Stop on compile error

### DIFF
--- a/packages/karma-typescript-postcss-transform/src/transform.spec.ts
+++ b/packages/karma-typescript-postcss-transform/src/transform.spec.ts
@@ -89,10 +89,10 @@ test("transformer should set the source property to the processed value", (t) =>
     const context = createContext("::placeholder {}");
 
     transform(require("autoprefixer"))(context, () => {
-        t.isEqual(context.source, "::-webkit-input-placeholder {}\n" +
-                                  "::-moz-placeholder {}\n" +
+        t.isEqual(context.source, "::-moz-placeholder {}\n" +
                                   ":-ms-input-placeholder {}\n" +
-                                  "::-ms-input-placeholder {}\n::placeholder {}");
+                                  "::-ms-input-placeholder {}\n" + 
+                                  "::placeholder {}");
     });
 });
 
@@ -102,17 +102,15 @@ test("transformer should use custom options", (t) => {
     const context = createContext("::placeholder {}");
 
     transform(require("autoprefixer"), { map: { inline: true } })(context, () => {
-        t.isEqual(context.source, "::-webkit-input-placeholder {}\n" +
-                                  "::-moz-placeholder {}\n" +
+        t.isEqual(context.source, "::-moz-placeholder {}\n" +
                                   ":-ms-input-placeholder {}\n" +
                                   "::-ms-input-placeholder {}" +
                                   "\n::placeholder {}" +
-                                  "\n/*# sourceMappingURL=data:application/json;base64," +
-                                  "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpbGUuY3NzIl0sIm5hb" +
-                                  "WVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLDZCQUFlO0FBQWYsb0JBQW" +
-                                  "U7QUFBZix3QkFBZTtBQUFmLHlCQUFlO0FBQWYsZUFBZSIsImZpbGU" +
-                                  "iOiJmaWxlLmNzcyIsInNvdXJjZXNDb250ZW50IjpbIjo6cGxhY2Vo" +
-                                  "b2xkZXIge30iXX0= */");
+                                  "\n/*# sourceMappingURL=data:application/json;base64," + 
+                                  "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpbGUuY3NzIl0sIm5hbWV" +
+                                  "zIjpbXSwibWFwcGluZ3MiOiJBQUFBLG9CQUFlO0FBQWYsd0JBQWU7QU" +
+                                  "FBZix5QkFBZTtBQUFmLGVBQWUiLCJmaWxlIjoiZmlsZS5jc3MiLCJzb" + 
+                                  "3VyY2VzQ29udGVudCI6WyI6OnBsYWNlaG9sZGVyIHt9Il19 */");
     });
 });
 

--- a/packages/karma-typescript/README.md
+++ b/packages/karma-typescript/README.md
@@ -355,6 +355,10 @@ If the defaults aren't enough, the settings can be configured from `karma.conf.j
   The directory of the `tsconfig.json` file will be used as the base path for the Typescript compiler, and if `karmaTypescriptConfig.tsconfig` isn't set, the `basePath` property of the Karma config will be used as the
   compiler base path instead.
 
+* **karmaTypescriptConfig.stopOnFailure** - Stop on any compiler error.<br/>
+  By default karma will stop when any typescript compile errors are encountered.<br/>
+  Setting this to false will allow test tobe run when typescript compile errors are present.
+
 Example of a full `karmaTypescriptConfig` configuration:
 
 ```javascript
@@ -431,7 +435,8 @@ karmaTypescriptConfig: {
     transformPath: function(filepath) {
         return filepath.replace(/\.(ts|tsx)$/, ".js");
     },
-    tsconfig: "./tsconfig.json"
+    tsconfig: "./tsconfig.json",
+    stopOnFailure: false
 }
 ```
 

--- a/packages/karma-typescript/README.md
+++ b/packages/karma-typescript/README.md
@@ -357,7 +357,7 @@ If the defaults aren't enough, the settings can be configured from `karma.conf.j
 
 * **karmaTypescriptConfig.stopOnFailure** - Stop on any compiler error.<br/>
   By default karma will stop when any typescript compile errors are encountered.<br/>
-  Setting this to false will allow test tobe run when typescript compile errors are present.
+  Setting this to false will allow tests to be run when typescript compile errors are present.
 
 Example of a full `karmaTypescriptConfig` configuration:
 

--- a/packages/karma-typescript/src/api/configuration.ts
+++ b/packages/karma-typescript/src/api/configuration.ts
@@ -14,6 +14,7 @@ export interface KarmaTypescriptConfig {
     reports?: Reports;
     transformPath?: (filepath: string) => string;
     tsconfig?: string;
+    stopOnFailure?: boolean;
 }
 
 export interface BundlerOptions {

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -106,7 +106,7 @@ export class Compiler {
 
             queued.callback({
                 ambientModuleNames,
-                hasError: this.errors.indexOf(queued.file.originalPath) !== -1,
+                hasError: this.config.stopOnFailure ? this.errors.indexOf(queued.file.originalPath) !== -1 : false,
                 isAmbientModule: ambientModuleNames && ambientModuleNames.length > 0,
                 isDeclarationFile: this.fileExtensionIs(sourceFile.fileName, ".d.ts"),
                 outputText: this.compiledFiles[queued.file.path],
@@ -150,7 +150,7 @@ export class Compiler {
 
     private outputDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>, host?: ts.FormatDiagnosticsHost): void {
 
-        if (!diagnostics || diagnostics.length === 0 || !this.config.stopOnFailure) {
+        if (!diagnostics || diagnostics.length === 0) {
             return;
         }
 

--- a/packages/karma-typescript/src/compiler/compiler.ts
+++ b/packages/karma-typescript/src/compiler/compiler.ts
@@ -150,7 +150,7 @@ export class Compiler {
 
     private outputDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>, host?: ts.FormatDiagnosticsHost): void {
 
-        if (!diagnostics || diagnostics.length === 0) {
+        if (!diagnostics || diagnostics.length === 0 || !this.config.stopOnFailure) {
             return;
         }
 

--- a/packages/karma-typescript/src/shared/configuration.ts
+++ b/packages/karma-typescript/src/shared/configuration.ts
@@ -34,6 +34,7 @@ export class Configuration implements KarmaTypescriptConfig {
     public reports: Reports;
     public transformPath: (filepath: string) => string;
     public tsconfig: string;
+    public stopOnFailure: boolean;
 
     public hasCoverageThreshold: boolean;
 
@@ -186,6 +187,7 @@ export class Configuration implements KarmaTypescriptConfig {
         this.tsconfig = this.karmaTypescriptConfig.tsconfig;
         this.assertExtendable("exclude");
         this.assertExtendable("include");
+        this.stopOnFailure = this.karmaTypescriptConfig.stopOnFailure || true;
     }
 
     private configurePreprocessor() {

--- a/packages/karma-typescript/src/shared/configuration.ts
+++ b/packages/karma-typescript/src/shared/configuration.ts
@@ -187,7 +187,7 @@ export class Configuration implements KarmaTypescriptConfig {
         this.tsconfig = this.karmaTypescriptConfig.tsconfig;
         this.assertExtendable("exclude");
         this.assertExtendable("include");
-        this.stopOnFailure = this.karmaTypescriptConfig.stopOnFailure || true;
+        this.stopOnFailure = this.karmaTypescriptConfig.stopOnFailure !== false;
     }
 
     private configurePreprocessor() {


### PR DESCRIPTION
Fix #274 by introducing a new variable called stopOnFailure (default true) which allows tests to be run when typescript compile errors are present.