### PR TITLE
fix: exit if the coverage threshold is not met

### DIFF
--- a/packages/karma-typescript/src/karma/reporter.ts
+++ b/packages/karma-typescript/src/karma/reporter.ts
@@ -11,6 +11,10 @@ import { Logger } from "log4js";
 import { Threshold } from "../istanbul/threshold";
 import { Configuration } from "../shared/configuration";
 
+type BrowserCollection = {
+    forEach: any[]['forEach'];
+}
+
 const reporterName = "karma-typescript";
 
 export class Reporter {
@@ -44,20 +48,19 @@ export class Reporter {
                 }
             };
 
-            this.onRunComplete = (browsers: any[], results: any) => {
+            this.onRunComplete = async (collection: BrowserCollection, results: any) => {
+                const browsers: any[] = [];
+                collection.forEach((browser) => browsers.push(browser));
 
-                browsers.forEach(async (browser: any) => {
+                let isBelowCoverageThreshold = false;
 
+                for(const browser of browsers) {
                     const coverage = that.coverageMap.get(browser);
                     const coverageMap = istanbulCoverage.createCoverageMap();
                     coverageMap.merge(coverage);
 
                     const sourceMapStore = istanbulSourceMaps.createSourceMapStore();
                     const remappedCoverageMap = await sourceMapStore.transformCoverage(coverageMap);
-
-                    if (results && config.hasCoverageThreshold && !threshold.check(browser, remappedCoverageMap)) {
-                        results.exitCode = 1;
-                    }
 
                     Object.keys(config.reports).forEach((reportType: any) => {
 
@@ -81,7 +84,15 @@ export class Reporter {
                             // @ts-ignore
                             .execute(context);
                     });
-                });
+
+                    const isCoverageCheckFailed = results && config.hasCoverageThreshold && !threshold.check(browser, remappedCoverageMap);
+
+                    isBelowCoverageThreshold = isBelowCoverageThreshold || isCoverageCheckFailed;
+                }
+
+                if (isBelowCoverageThreshold) {
+                    process.exit(1);
+                }
             };
         };
 


### PR DESCRIPTION
I've investigated a bit what the differences were between `4.1.1` and `5.x.y`, I noticed that the package was previously doing `sync` operations.

Since `5.0.0` the coverage calculations are done via the `istanbul-lib-coverage` package to process the results.

The issue here is that the processing is now async and mutation of the `results.exitCode` property is now part of a `microTask`.

The only solution I could find was to aggregate all of the threshold checks and actually exit once all of the checks are performed.

fix #376