### PR TITLE
Add Typescript v4 as allowed peerDependency

### DIFF
--- a/packages/karma-typescript/package.json
+++ b/packages/karma-typescript/package.json
@@ -155,6 +155,6 @@
   },
   "peerDependencies": {
     "karma": "1 || 2 || 3 || 4 || 5",
-    "typescript": "1 || 2 || 3"
+    "typescript": "1 || 2 || 3 || 4"
   }
 }


### PR DESCRIPTION
To avoid warnings and make installations work with npm v7 without errors.