### PR TITLE
Don't kill process when coverage threshold isn't met if singleRun is false

### DIFF
--- a/packages/karma-typescript/src/karma/reporter.ts
+++ b/packages/karma-typescript/src/karma/reporter.ts
@@ -94,7 +94,7 @@ export class Reporter {
                 const isCoverageCheckFailed = (await Promise.all(coverageChecks))
                     .some(isCheckFailed => isCheckFailed);
 
-                if (isCoverageCheckFailed) {
+                if (isCoverageCheckFailed && config.karma.singleRun) {
                     process.exit(1);
                 }
             };


### PR DESCRIPTION
When running Karma with autowatch enabled, the process will exit if coverage thresholds aren't met. This conditional just ensures singleRun is enabled before killing the process.

Fixes https://github.com/monounity/karma-typescript/issues/415