### PR TITLE
Update peer dependency to support `karma` 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Install via `npm`:
 
-```
+```bash
 npm install --save-dev karma-typescript
 ```
 
@@ -72,7 +72,6 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/karma-typescript/backer/28/website" target="_blank"><img src="https://opencollective.com/karma-typescript/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/karma-typescript/backer/29/website" target="_blank"><img src="https://opencollective.com/karma-typescript/backer/29/avatar.svg"></a>
 
-
 ## Sponsors
 
 Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/karma-typescript#sponsor)]
@@ -108,5 +107,4 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 <a href="https://opencollective.com/karma-typescript/sponsor/28/website" target="_blank"><img src="https://opencollective.com/karma-typescript/sponsor/28/avatar.svg"></a>
 <a href="https://opencollective.com/karma-typescript/sponsor/29/website" target="_blank"><img src="https://opencollective.com/karma-typescript/sponsor/29/avatar.svg"></a>
 
-
-© 2016-2020 Erik Barke, Monounity
+© 2016-2021 Erik Barke, Monounity

--- a/examples/angular2/package.json
+++ b/examples/angular2/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^13.9.1",
     "core-js": "^3.6.4",
     "jasmine-core": "^3.5.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^3.1.1",
     "karma-typescript": "latest",

--- a/examples/angularjs/package.json
+++ b/examples/angularjs/package.json
@@ -20,7 +20,7 @@
     "angular": "^1.8.0",
     "angular-mocks": "^1.6.4",
     "jasmine-core": "^3.3.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^2.0.1",
     "karma-typescript": "latest",

--- a/examples/docker/package.json
+++ b/examples/docker/package.json
@@ -17,7 +17,7 @@
     "express": "^4.13.3",
     "@types/jasmine": "^2.5.35",
     "jasmine-core": "^2.4.1",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",

--- a/examples/mocha/package.json
+++ b/examples/mocha/package.json
@@ -17,7 +17,7 @@
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^5.2.5",
     "expect.js": "^0.3.1",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-mocha": "^1.3.0",

--- a/examples/typescript-1.6.2/package.json
+++ b/examples/typescript-1.6.2/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/jasmine": "^3.4.0",
     "jasmine-core": "^3.4.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-jasmine": "^2.0.1",

--- a/examples/typescript-1.8.10/package.json
+++ b/examples/typescript-1.8.10/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/jasmine": "^3.4.0",
     "jasmine-core": "^3.4.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-jasmine": "^2.0.1",

--- a/examples/typescript-latest/package.json
+++ b/examples/typescript-latest/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/jasmine": "^3.4.0",
     "jasmine-core": "^3.3.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-jasmine": "^2.0.1",

--- a/packages/karma-typescript-angular2-transform/package.json
+++ b/packages/karma-typescript-angular2-transform/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@angular/core": "^10.0.9",
-    "@types/karma": "^5.0.0",
+    "@types/karma": "^6.1.0",
     "@types/lodash": "^4.14.159",
     "@types/node": "^14.0.27",
     "@types/sinon": "^9.0.4",

--- a/packages/karma-typescript-cssmodules-transform/package.json
+++ b/packages/karma-typescript-cssmodules-transform/package.json
@@ -42,7 +42,7 @@
     "log4js": "^6.3.0"
   },
   "devDependencies": {
-    "@types/karma": "^5.0.0",
+    "@types/karma": "^6.1.0",
     "@types/lodash": "^4.14.159",
     "@types/node": "^14.0.27",
     "@types/sinon": "^9.0.4",

--- a/packages/karma-typescript-es6-transform/package.json
+++ b/packages/karma-typescript-es6-transform/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.9",
-    "@types/karma": "^5.0.0",
+    "@types/karma": "^6.1.0",
     "@types/lodash": "^4.14.159",
     "@types/node": "^14.0.27",
     "@types/sinon": "^9.0.4",

--- a/packages/karma-typescript-es6-transform/src/transform.ts
+++ b/packages/karma-typescript-es6-transform/src/transform.ts
@@ -59,7 +59,7 @@ const configure = (options?: babel.TransformOptions) : kt.Transform => {
 
             try {
                 context.source = babel.transform(context.source, options).code;
-                context.js.ast = acorn.parse(context.source, { sourceType: "module" });
+                context.js.ast = acorn.parse(context.source, { sourceType: "module", ecmaVersion: "latest" });
                 return callback(undefined, true);
             }
             catch (error) {

--- a/packages/karma-typescript-postcss-transform/package.json
+++ b/packages/karma-typescript-postcss-transform/package.json
@@ -41,7 +41,7 @@
     "log4js": "^6.3.0"
   },
   "devDependencies": {
-    "@types/karma": "^5.0.0",
+    "@types/karma": "^6.1.0",
     "@types/lodash": "^4.14.159",
     "@types/node": "^14.0.27",
     "@types/sinon": "^9.0.4",

--- a/packages/karma-typescript/README.md
+++ b/packages/karma-typescript/README.md
@@ -19,7 +19,7 @@ The easiest way is to keep `karma-typescript` as a devDependency in `package.jso
 ```json
 {
   "devDependencies": {
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-typescript": "5.2.0"
   }
 }

--- a/packages/karma-typescript/package.json
+++ b/packages/karma-typescript/package.json
@@ -140,7 +140,7 @@
     "@types/istanbul-lib-report": "^3.0.0",
     "@types/istanbul-lib-source-maps": "^4.0.0",
     "@types/istanbul-reports": "^3.0.0",
-    "@types/karma": "^5.0.0",
+    "@types/karma": "^6.1.0",
     "@types/lodash": "^4.14.159",
     "@types/minimatch": "^3.0.3",
     "@types/mock-require": "^2.0.0",
@@ -157,7 +157,7 @@
     "typescript": "latest"
   },
   "peerDependencies": {
-    "karma": "1 || 2 || 3 || 4 || 5",
+    "karma": "1 || 2 || 3 || 4 || 5 || 6",
     "typescript": "1 || 2 || 3 || 4"
   }
 }

--- a/packages/karma-typescript/src/bundler/validator.ts
+++ b/packages/karma-typescript/src/bundler/validator.ts
@@ -13,7 +13,10 @@ export class Validator {
         if (this.config.bundlerOptions.validateSyntax) {
 
             try {
-                acorn.parse(bundle);
+                acorn.parse(bundle, {
+                    // defaults to TS "latest" version
+                    ecmaVersion: "latest"
+                });
             }
             catch (error) {
 

--- a/tests/integration-latest/package.json
+++ b/tests/integration-latest/package.json
@@ -17,7 +17,7 @@
     "@types/jasmine": "^2.5.37",
     "date-fns": "^2.16.1",
     "jasmine-core": "^2.6.0",
-    "karma": "^5.0.0",
+    "karma": "^6.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",


### PR DESCRIPTION
- updates peer dependencies mark to support `karma` v6
- update `karma` dependency to `6.1.0`
- update `@types/karma` to `6.1.0`

`karma` 6.1.0 is breaking (kind of), mostly for Dart users. Should not have direct impact on Karma TS integration, but peer dependency definiiton makes using v6 impossible. Hence this change.
Tested locally, changes applied and tested in all packages, except of:
- Docker (requires app rewrite, it fails at runtime due to yars/args error)
- Gulp plugin (I cannot take a dent on how it works)

Thanks!

Update acorn.parse usage to support `ecmaVersion`

Opted to `lastest`, the reasoning is TS is defined as `lastest`.

Fixes #409

[README] bump copy year and minor cleanup