### PR TITLE
fix: use nullish coalescing for coverage directory paths

### DIFF
--- a/packages/karma-typescript/src/karma/reporter.ts
+++ b/packages/karma-typescript/src/karma/reporter.ts
@@ -106,12 +106,12 @@ export class Reporter {
     private getReportDestination(browser: any, reportConfig: any, reportType: any) {
 
         if (lodash.isPlainObject(reportConfig)) {
-            let subdirectory = reportConfig.subdirectory || browser.name;
+            let subdirectory = reportConfig.subdirectory ?? browser.name;
             if (typeof subdirectory === "function") {
                 subdirectory = subdirectory(browser);
             }
 
-            return path.join(reportConfig.directory || "coverage", subdirectory);
+            return path.join(reportConfig.directory ?? "coverage", subdirectory);
         }
 
         if (lodash.isString(reportConfig) && reportConfig.length > 0) {


### PR DESCRIPTION
Situation:

I want to output everything in `./coverage` this cannot be easily achieve at the moment. If the `subdirectory` is set to `''`, it will fallback to the browser-name value.

Alternative:

At the moment I'm doing the following to achieve the desired result on my project: 
```
'html': {
    'directory': 'coverage',
    'subdirectory': () => '',
},
'lcovonly': {
    'directory': 'coverage',
    'subdirectory': () => '',
},
```

Solution:

Use nullish, this way the defaults will be used only when the values are `undefined` or `null`.