### PR TITLE
Add documentation update for acornOptions

### DIFF
--- a/packages/karma-typescript/README.md
+++ b/packages/karma-typescript/README.md
@@ -112,6 +112,13 @@ If the defaults aren't enough, the settings can be configured from `karma.conf.j
 * **karmaTypescriptConfig.bundlerOptions.addNodeGlobals** - Boolean indicating whether the global variables
   `process` and `Buffer` should be added to the bundle.<br/>
   Defaults to `true`.
+  
+* **karmaTypescriptConfig.bundlerOptions.acornOptions** - An object literal with keys/values which are passed as configuration 
+  options to the [Acorn](https://github.com/acornjs/acorn) parser used by the bundler.  The most notable of these keys is
+  `ecmaScript` which sets the ECMAScript target used by the parser.  If code has dependencies that use a newer version of 
+  ECMAScript than the bundler defaults to (ES5), parsing errors will result when the source-reader tries to bundle dependencies 
+  (e.g. dependencies that use `bigint` literals like `1n` will cause an error during code compilation unless this option is 
+  explicitly set to 11(ES2020).  A complete list of options can be found in the [Acorn documentation](https://github.com/acornjs/acorn/tree/master/acorn#interface). 
 
 * **karmaTypescriptConfig.bundlerOptions.constants** - An object literal with keys/values which will be available as global
   variables in the bundle. The keys are expected to be strings and any non-string value will be stringified with `JSON.stringify`.


### PR DESCRIPTION
This adds documentation for the `acornOptions` configuration key under `bundlerOptions`, addressing previous issues such as #255  and #520.