### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/karma-typescript/src/karma/framework.ts
+++ b/packages/karma-typescript/src/karma/framework.ts
@@ -40,7 +40,7 @@ export class Framework {
 
     private replacer(key: string, value: string) {
         if (key && typeof value === "function") {
-            return (value + "").substr(0, 100) + "...";
+            return (value + "").slice(0, 100) + "...";
         }
         return value;
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.